### PR TITLE
Manifest: add ScreenSaver interface for inihibiting idle

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@
 
 - **`--socket=x11`**: ROTA is built with Godot Engine 3.6. Wayland support didn't come until [Godot 4.3](https://godotengine.org/article/dev-snapshot-godot-4-3-dev-3/#wayland-support-for-linux), and porting from 3.6 to 4.3 is pretty monumental; thus X11/XWayland needs to be used unless/until someone volunteers to port to Godot Engine 4.3+.
 
-- **`--device=all`**: Necessary for controller support. See: https://github.com/flathub/net.hhoney.rota/pull/2
+- **`--device=all`**: Currently necessary for controller support. See: https://github.com/flathub/net.hhoney.rota/pull/2
+
+- **`--talk-name=org.freedesktop.ScreenSaver`**: Allows the game to inhibit idle. See: https://github.com/godotengine/godot/issues/108634
 
 [flathub]: https://flathub.org/apps/details/net.hhoney.rota

--- a/net.hhoney.rota.yml
+++ b/net.hhoney.rota.yml
@@ -7,9 +7,16 @@ sdk: org.freedesktop.Sdk
 command: godot-runner
 finish-args:
   - --share=ipc
-  - --socket=x11
   - --socket=pulseaudio
+
+  # Wayland support not added until Godot Engine 4.3
+  - --socket=x11
+
+  # Currently necessary for controller support
   - --device=all
+
+  # Necessary to inhibit idle (screensaver/suspend) when using a controller
+  - --talk-name=org.freedesktop.ScreenSaver
 modules:
   - name: rota
     buildsystem: simple


### PR DESCRIPTION
Allows the game to inhibit idle (screensaver/suspend), e.g. when playing with a controller. See: https://github.com/HarmonyHoney/ROTA/pull/37, https://github.com/godotengine/godot/issues/108634.